### PR TITLE
 Jammy Jellyfish 릴리스 노트 Ubuntu Desktop 부분 번역

### DIFF
--- a/content/post/jamme-jellyfish-release-notes/index.md
+++ b/content/post/jamme-jellyfish-release-notes/index.md
@@ -122,36 +122,36 @@ nftables is now the default backend for the firewall. All applications on the sy
 
 `scp` offers a [`-s` command line option](http://manpages.ubuntu.com/manpages/jammy/en/man1/scp.1.html) to use [sftp mode rather than scp mode](https://www.openssh.com/txt/release-8.9) when handling remote filenames. This new, safer, behaviour will eventually become the default.
 
-## Ubuntu Desktop
+## 우분투 데스크톱
 
-* Ubuntu now offers [10 color choices](https://discourse.ubuntu.com/t/yaru-accent-colors-are-coming-to-jammy/27200) each in dark and light styles
-* Firefox is now only provided in Ubuntu as a snap. Some benefits include
-  * Directly maintained by Mozilla
-  * More maintainable for the entire Ubuntu LTS lifecycle
-  * … Which means faster access to the newest Firefox versions
-  * Easily switch to a different Firefox flavor with snap channels including `esr/stable`, `latest/candidate`, `latest/beta`, and `latest/edge`
-  * Sandboxed for improved security hardening for this critical app
-* Desktop icons are shown in the bottom right by default but this can be changed through new settings added to the Appearance panel of the Settings app.
-* Also there are new settings to control the Dock look and behavior
-* Dock devices and filemanager integration has been improved
+* 이제 우분투에서 [10가지의 색상 선택지를](https://discourse.ubuntu.com/t/yaru-accent-colors-are-coming-to-jammy/27200) 다크 모드와 라이트 모드로 제공합니다.
+* 이제 Firefox 는 우분투에서 Snap으로만 제공됩니다. 아래와 같은 장점이 있습니다
+  * 모질라에서 직접 유지보수 
+  * 전체 우분투 LTS 수명주기 동안 유지보수 용이성 향상
+  * … 이는 최신 버전의 Firefox에 더 빠르게 접근할 수 있음을 의미합니다
+  * `esr/stable`, `latest/candidate`, `latest/beta`및 `latest/edge`를 포함한 다른 종류의 Firefox 로 쉽게 변경
+  * 중요한 앱인 Firefox의 보안 강화를 위한 샌드박스 처리
+* 데스크톱 아이콘은 기본적으로 우측 하단에 표시되지만 설정 앱의 모양 패널에 추가된 새로운 설정으로 변경할 수 있습니다.
+* 독의 모양과 동작을 바꿀 수 있는 새로운 설정도 있습니다
+* 독의 디바이스 및 파일 관리자 연동이 향상되었습니다
 
 ### GNOME :footprints:
 
-* GNOME has been updated to include new features and fixes from [GNOME 41](https://release.gnome.org/41/) and [GNOME 42](https://release.gnome.org/42/) 
-* Several apps are still at their 41 version numbers to provide a more time-tested experience for the LTS desktop by mostly avoiding libadwaita.
-* The new cross-desktop [dark style](https://discourse.ubuntu.com/t/ubuntu-22-04-lts-dark-style-changes/27206) preference is supported.
-* GNOME Shell and mutter have lots of performance improvements including the triple buffering patch.
-* The default session for most systems that don't have an Nvidia graphics card is now Wayland. If you need a non-Wayland session, you can choose the *Ubuntu on Xorg* session by clicking the gear button after selecting your name on the login screen.
-* Hardware with privacy screen support is now supported
-* RDP is now available for sharing your desktop remotely. Legacy VNC is still available, but it is strongly recommended to use RDP for better security, privacy, and performance. If you were previously using VNC, you'll need to manually re-enable desktop sharing in the Settings app and get your new login information.
+* GNOME을 [GNOME 41](https://release.gnome.org/41/)및 [GNOME 42](https://release.gnome.org/42/)의 새로운 기능과 수정사항을 포함하도록 업데이트 하였습니다
+* 여러 프로그램은 대부분 libadwaita를 피하여 LTS 데스크톱에 대해 더 검증된 경험을 제공하기 위해 여전히 41 버전대로 유지됩니다.
+* 데스크톱 전반에 걸친 [다크 스타일](https://discourse.ubuntu.com/t/ubuntu-22-04-lts-dark-style-changes/27206) 설정을 새로 지원합니다.
+* GNOME 셸과 Mutter에 트리플 버퍼링 패치를 비롯한 수많은 성능 개선이 있습니다.
+* 이제 Nvidia 그래픽 카드를 쓰지 않는 대부분의 시스템의 기본 세션은 웨일랜드 세션입니다. 비-웨일랜드 세션이 필요하신 경우, 로그인 화면에서 이름을 선택한 후 우측 하단의 톱니바퀴 아이콘을 클릭하여 *우분투 (Xorg)* 를 선택하실 수 있습니다.
+* 이제 사생활 보호 화면 지원이 있는 하드웨어를 지원합니다
+* 데스크톱 원격 공유에 RDP를 사용하실 수 있습니다. 기존의 VNC도 여전히 있으나, 더 나은 보안, 사생활 보호 및 성능을 위해 RDP를 사용 하시는 것을 강력히 권장합니다. 기존에 VNC를 사용해 오셨다면, 설정 앱 에서 데스크톱 공유를 수동으로 다시 켜고 새로 로그인 정보를 얻으셔야 할 겁니다. 
 
-### Updated Applications
+### 업데이트된 프로그램
 
 * Firefox 99 :fire::fox_face:
 * [LibreOffice 7.3](https://wiki.documentfoundation.org/ReleaseNotes/7.3) :books:
 * Thunderbird 91 :cloud_with_lightning::bird:
 
-### Updated Subsystems
+### 업데이트된 하위 시스템
 
 * [BlueZ 5.63](https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/ChangeLog?id=5.63)
 * [CUPS 2.4](https://github.com/OpenPrinting/cups/blob/v2.4.1/CHANGES.md)

--- a/content/post/jamme-jellyfish-release-notes/index.md
+++ b/content/post/jamme-jellyfish-release-notes/index.md
@@ -126,7 +126,7 @@ nftables is now the default backend for the firewall. All applications on the sy
 
 * 이제 우분투에서 [10가지의 색상 선택지를](https://discourse.ubuntu.com/t/yaru-accent-colors-are-coming-to-jammy/27200) 다크 모드와 라이트 모드로 제공합니다.
 * 이제 Firefox 는 우분투에서 Snap으로만 제공됩니다. 아래와 같은 장점이 있습니다
-  * 모질라에서 직접 유지보수 
+  * Mozilla에서 직접 유지보수 
   * 전체 우분투 LTS 수명주기 동안 유지보수 용이성 향상
   * … 이는 최신 버전의 Firefox에 더 빠르게 접근할 수 있음을 의미합니다
   * `esr/stable`, `latest/candidate`, `latest/beta`및 `latest/edge`를 포함한 다른 종류의 Firefox 로 쉽게 변경
@@ -137,11 +137,11 @@ nftables is now the default backend for the firewall. All applications on the sy
 
 ### GNOME :footprints:
 
-* GNOME을 [GNOME 41](https://release.gnome.org/41/)및 [GNOME 42](https://release.gnome.org/42/)의 새로운 기능과 수정사항을 포함하도록 업데이트 하였습니다
+* GNOME을 [GNOME 41](https://release.gnome.org/41/)및 [GNOME 42](https://release.gnome.org/42/)의 새로운 기능과 수정사항을 포함하도록 업데이트했습니다
 * 여러 프로그램은 대부분 libadwaita를 피하여 LTS 데스크톱에 대해 더 검증된 경험을 제공하기 위해 여전히 41 버전대로 유지됩니다.
 * 데스크톱 전반에 걸친 [다크 스타일](https://discourse.ubuntu.com/t/ubuntu-22-04-lts-dark-style-changes/27206) 설정을 새로 지원합니다.
 * GNOME 셸과 Mutter에 트리플 버퍼링 패치를 비롯한 수많은 성능 개선이 있습니다.
-* 이제 Nvidia 그래픽 카드를 쓰지 않는 대부분의 시스템의 기본 세션은 웨일랜드 세션입니다. 비-웨일랜드 세션이 필요하신 경우, 로그인 화면에서 이름을 선택한 후 우측 하단의 톱니바퀴 아이콘을 클릭하여 *우분투 (Xorg)* 를 선택하실 수 있습니다.
+* 이제 Nvidia 그래픽 카드를 쓰지 않는 대부분의 시스템의 기본 세션은 Wayland 세션입니다. 비-Wayland 세션이 필요하신 경우, 로그인 화면에서 이름을 선택한 후 우측 하단의 톱니바퀴 아이콘을 클릭하여 *우분투 (Xorg)* 를 선택하실 수 있습니다.
 * 이제 사생활 보호 화면 지원이 있는 하드웨어를 지원합니다
 * 데스크톱 원격 공유에 RDP를 사용하실 수 있습니다. 기존의 VNC도 여전히 있으나, 더 나은 보안, 사생활 보호 및 성능을 위해 RDP를 사용 하시는 것을 강력히 권장합니다. 기존에 VNC를 사용해 오셨다면, 설정 앱 에서 데스크톱 공유를 수동으로 다시 켜고 새로 로그인 정보를 얻으셔야 할 겁니다. 
 


### PR DESCRIPTION
Closes #13

- Ubuntu Desktop: 많은 프로그램 UI상에서 한글로 "우분투"라고 나오는 경우가 많아 한글로 옮겼습니다.
- Applications: 독 및 설정 앱에서 "프로그램"으로 번역되어 있어 이를 따라 번역하였습니다.